### PR TITLE
Feature optional

### DIFF
--- a/gumdrop_derive/src/lib.rs
+++ b/gumdrop_derive/src/lib.rs
@@ -1263,6 +1263,7 @@ struct AttrOpts {
     meta: Option<String>,
     parse: Option<ParseFn>,
     default: Option<String>,
+    optional: bool,
     #[cfg(feature = "default_expr")]
     default_expr: Option<Expr>,
 
@@ -1357,18 +1358,17 @@ impl Action {
                     "Option" if param.is_some() => {
                         let tuple_len = tuple_len(param.unwrap());
 
-                        Action::SetOption(ParseMethod{
-                            parse_fn: opts.parse.clone().unwrap_or_default(),
-                            tuple_len,
-                        })
-                    }
-                    "Optional" if param.is_some() => {
-                        let tuple_len = tuple_len(param.unwrap());
-
-                        Action::SetOptional(ParseMethod{
-                            parse_fn: opts.parse.clone().unwrap_or_default(),
-                            tuple_len,
-                        })
+                        if opts.optional {
+                            Action::SetOptional(ParseMethod{
+                                parse_fn: opts.parse.clone().unwrap_or_default(),
+                                tuple_len,
+                            })
+                        } else {
+                            Action::SetOption(ParseMethod{
+                                parse_fn: opts.parse.clone().unwrap_or_default(),
+                                tuple_len,
+                            })
+                        }
                     }
                     _ => {
                         if let Some(meth) = &opts.multi {
@@ -1548,6 +1548,7 @@ impl AttrOpts {
                             "no_help_flag" => self.no_help_flag = true,
                             "no_short" => self.no_short = true,
                             "no_long" => self.no_long = true,
+                            "optional" => self.optional = true,
                             "no_multi" => self.no_multi = true,
                             "required" => self.required = true,
                             "not_required" => self.not_required = true,
@@ -1879,7 +1880,7 @@ impl<'a> Opt<'a> {
                 let act = parse.make_action_type(true);
 
                 quote!{
-                    _result.#field = ::gumdrop::Optional{ val: Some(#act) };
+                    _result.#field = ::std::option::Option::Some(#act);
                 }
             }
             Switch => quote!{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,25 @@ use std::fmt;
 use std::slice::Iter;
 use std::iter::Peekable;
 use std::str::Chars;
+use std::str::FromStr;
+
+#[derive(Debug, Default)]
+pub struct Optional<T: From<String>> {
+    pub val: Option<T>,
+}
+
+impl<T: From<String>> FromStr for Optional<T> {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s_string = s.to_string();
+        let o = Optional {
+            val: Some(s_string.into())
+        };
+
+        Ok(o)
+    }
+}
 
 /// Represents an error encountered during argument parsing
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,25 +175,6 @@ use std::fmt;
 use std::slice::Iter;
 use std::iter::Peekable;
 use std::str::Chars;
-use std::str::FromStr;
-
-#[derive(Debug, Default)]
-pub struct Optional<T: From<String>> {
-    pub val: Option<T>,
-}
-
-impl<T: From<String>> FromStr for Optional<T> {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s_string = s.to_string();
-        let o = Optional {
-            val: Some(s_string.into())
-        };
-
-        Ok(o)
-    }
-}
 
 /// Represents an error encountered during argument parsing
 #[derive(Debug)]


### PR DESCRIPTION
adds `#[options(optional)]` derive feature.
optional lets a `thing: Option<String>` be valid for: `--thing` and `--thing VALUE` where if used as a flag, it will be `Some("")`

Also fixes parsing behavior where this could happen:

```
--some-option --some-flag
```

the above could parse into: `some_option = Some("--some-flag")`, which I believe is undesirable, so I changed the parser to peek ahead and check for this type of scenario (by seeing if the first character is a dash), and to error if it is. Note that this is consistent with the optional feature mentioned above, so it works as expected.

The only limitations are:
- cant ever have a value start with a dash (I think this is typical of CLI programs though)
- cant use meta derived names with optional fields